### PR TITLE
docs: add raspberry pi results

### DIFF
--- a/tablespaces/README.md
+++ b/tablespaces/README.md
@@ -271,14 +271,15 @@ ORDER BY 1,2;
 
 ### Database larger than memory
 
-| Author             | Date       | Environment | Postgres cores | Postgres memory | pgbench scale | DB size | Clients | Time | TPS #1 | TPS #2 | TPS #3 | TPS #4 |
-| -------------------|------------|-------------|----------------|-----------------|---------------|---------|---------|------|--------|--------|--------|--------|
-| Gabriele Bartolini | 2024-02-14 | EKS         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 4       | 300  |        |   554  |   637  | 1,070  |
-| Gabriele Bartolini | 2024-02-14 | EKS         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 8       | 300  |        |   889  | 1,157  | 1,441  |
-| Gabriele Bartolini | 2024-02-14 | EKS         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 16      | 300  | 1,109  | 1,272  | 1,476  | 1,403  |
-| Gabriele Bartolini | 2024-02-19 | EKS         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 4       | 300  |        |   819  |        |   522  |
-| Gabriele Bartolini | 2024-02-19 | EKS         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 8       | 300  |        |   822  |        |   963  |
-| Gabriele Bartolini | 2024-02-15 | EKS         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 16      | 300  |        | 1,244  |        | 1,293  |
+| Author             | Date       | Environment                               | Postgres cores | Postgres memory | pgbench scale | DB size | Clients | Time | TPS #1 | TPS #2 | TPS #3 | TPS #4 |
+| -------------------|------------|-------------------------------------------|----------------|-----------------|---------------|---------|---------|------|--------|--------|--------|--------|
+| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 4       | 300  |        |   554  |   637  | 1,070  |
+| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 8       | 300  |        |   889  | 1,157  | 1,441  |
+| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 16      | 300  | 1,109  | 1,272  | 1,476  | 1,403  |
+| Gabriele Bartolini | 2024-02-19 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 4       | 300  |        |   819  |        |   522  |
+| Gabriele Bartolini | 2024-02-19 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 8       | 300  |        |   822  |        |   963  |
+| Gabriele Bartolini | 2024-02-15 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 16      | 300  |        | 1,244  |        | 1,293  |
+| Jonathan Battiato  | 2024-02-19 | k3s 1.28.6<br/>on 4 RPi4<br/>SSD+Longhorn | 1.5            |  4GB            | 4500          |    66GB | 16      | 300  | 222    | 218    |        |        |
 
 ### Database fitting entirely in memory
 

--- a/tablespaces/README.md
+++ b/tablespaces/README.md
@@ -271,15 +271,16 @@ ORDER BY 1,2;
 
 ### Database larger than memory
 
-| Author             | Date       | Environment                               | Postgres cores | Postgres memory | pgbench scale | DB size | Clients | Time | TPS #1 | TPS #2 | TPS #3 | TPS #4 |
-| -------------------|------------|-------------------------------------------|----------------|-----------------|---------------|---------|---------|------|--------|--------|--------|--------|
-| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 4       | 300  |        |   554  |   637  | 1,070  |
-| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 8       | 300  |        |   889  | 1,157  | 1,441  |
-| Gabriele Bartolini | 2024-02-14 | EKS                                       | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 16      | 300  | 1,109  | 1,272  | 1,476  | 1,403  |
-| Gabriele Bartolini | 2024-02-19 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 4       | 300  |        |   819  |        |   522  |
-| Gabriele Bartolini | 2024-02-19 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 8       | 300  |        |   822  |        |   963  |
-| Gabriele Bartolini | 2024-02-15 | EKS                                       | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 16      | 300  |        | 1,244  |        | 1,293  |
-| Jonathan Battiato  | 2024-02-19 | k3s 1.28.6<br/>on 4 RPi4<br/>SSD+Longhorn | 1.5            |  4GB            | 4500          |    66GB | 16      | 300  | 222    | 218    |        |        |
+| Author             | Date       | Environment                                 | Postgres cores | Postgres memory | pgbench scale | DB size | Clients | Time | TPS #1 | TPS #2 | TPS #3 | TPS #4 |
+| -------------------|------------|---------------------------------------------|----------------|-----------------|---------------|---------|---------|------|--------|--------|--------|--------|
+| Gabriele Bartolini | 2024-02-14 | EKS                                         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 4       | 300  |        |   554  |   637  | 1,070  |
+| Gabriele Bartolini | 2024-02-14 | EKS                                         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 8       | 300  |        |   889  | 1,157  | 1,441  |
+| Gabriele Bartolini | 2024-02-14 | EKS                                         | 1.5 (r5.large) | 14GB            | 4500          |    66GB | 16      | 300  | 1,109  | 1,272  | 1,476  | 1,403  |
+| Gabriele Bartolini | 2024-02-19 | EKS                                         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 4       | 300  |        |   819  |        |   522  |
+| Gabriele Bartolini | 2024-02-19 | EKS                                         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 8       | 300  |        |   822  |        |   963  |
+| Gabriele Bartolini | 2024-02-15 | EKS                                         | 1.5 (r5.large) | 14GB            | 45000         |   657GB | 16      | 300  |        | 1,244  |        | 1,293  |
+| Jonathan Battiato  | 2024-02-19 | k3s 1.28.6<br/>on 4 RPi4<br/>SSD+Longhorn   | 1.5            |  4GB            | 4500          |    66GB | 16      | 300  | 222    | 218    |        |        |
+| Jonathan Battiato  | 2024-02-20 | k3s 1.28.6<br/>on 4 RPi4<br/>SSD+local-path | 1.5            |  4GB            | 4500          |    66GB | 16      | 300  | 246    | 245    |        |        |
 
 ### Database fitting entirely in memory
 


### PR DESCRIPTION
## Tests

I've only tested the following clusters:

* 01-pgdata-only.yaml
* 02-pgdata-wal.yaml

On two different storage classes:
* longhorn-pg
* localpath

The tablespace ones would not make sense for my use case.

## Environment

Hardware:
* 3 Raspberry Pi v4 8GB
* 3 SSD 1TB attached through USB 3.0 on each of the 8GB Rpi
* 1 Raspberry Pi v4 4GB
* 1 HDD 1TB attached to 4GB RPi through USB 3.0

Kubernetes:
* k3s 1.28.6
  * 3 CP nodes with `etcd` in high availability mode
  * 1 worker node
* Longhorn 1.6.0
* Calico 1.26.1

## StorageClass

### longhorn-pg:
* no replicas
* data locality: strict-local

### localpath
* provisioner: rancher.io/local-path
* no replicas
* data locality

## Node Labels
* `workload: postgres` set in one of the master nodes with 8GB RAM
* `workload: pgbench` set in the Rpi with 4GB RAM

## Cluster Parameters
```yaml
  # Request Guaranteed QoS
  resources:
    requests:
      memory: '4Gi'
      cpu: 1.5 
    limits:
      memory: '4Gi'
      cpu: 1.5 
```
```yaml
      # Memory configuration
      shared_buffers: '4GB'
      maintenance_work_mem: '1GB'
      effective_cache_size: '3GB'
```